### PR TITLE
draw_summary_table now handles different wtp values

### DIFF
--- a/R/ShinyPSA_R6.R
+++ b/R/ShinyPSA_R6.R
@@ -1166,6 +1166,31 @@ ShinyPSA <- R6::R6Class(
       ## Set currency label if none were provided:----
       if(is.null(.units_) | length(.units_) != 1) .units_ = "\u00A3"
 
+      ## Sort out .wtp values:----
+      ### Remove wtp values greater than max WTP set by user:
+      if(is.null(.wtp_))
+        .wtp_ <- c(20000, 30000)
+      if(!is.null(.wtp_))
+        if(length(.wtp_) < 1)
+          .wtp_ <- NULL
+      if(!is.null(.wtp_))
+        .wtp_ <- .wtp_[!is.na(.wtp_)]
+      if(any(.wtp_ > max(.PSA_data$WTPs)))
+        .wtp_ <- c(.wtp_[.wtp_ < max(.PSA_data$WTPs)],
+                   max(.PSA_data$WTPs))
+      ### replace unevaluated wtp with nearest replacements:
+      wtp_index_ <- purrr::map_dbl(
+        .x = .wtp_,
+        .f = function(wtp_ = .x) {
+          which.min(
+            abs(
+              wtp_ - .PSA_data$WTPs
+            )
+          )
+        }
+      )
+      .wtp_ <- unique(.PSA_data$WTPs[wtp_index_])
+
       ## Get the ICER table from the result's object:----
       ICER_tbl <- .PSA_data[["ICER"]]
 

--- a/R/draw_summary_table_.R
+++ b/R/draw_summary_table_.R
@@ -1,3 +1,13 @@
+################################################################################
+#
+# Script Name:        draw_summary_table_.R
+# Module Name:        Economic/PSA
+# Script Description: Defines the function that creates a table that
+#                     summarises the PSA results.
+# Author:             WM-University of Sheffield (wmamohammed1@sheffield.ac.uk)
+#
+################################################################################
+
 #' Draw results summary table
 #'
 #' @param .PSA_data A list of class shinyPSA that contains summary PSA
@@ -52,17 +62,43 @@
 #' t
 #' }
 #'
-draw_summary_table_ = function(.PSA_data, .wtp_ = c(20000, 30000),
-                               .units_ = "\u00A3",
-                               .effects_label_ = "QALYs",
-                               .beautify_ = TRUE,
-                               .long_ = TRUE,
-                               .individual_evpi_ = TRUE,
-                               .evpi_population_ = NULL,
-                               .discount_rate_ = 0.035,
-                               .time_horion_ = NULL) {
+draw_summary_table_ <- function(.PSA_data,
+                                .wtp_ = c(20000, 30000),
+                                .units_ = "\u00A3",
+                                .effects_label_ = "QALYs",
+                                .beautify_ = TRUE,
+                                .long_ = TRUE,
+                                .individual_evpi_ = TRUE,
+                                .evpi_population_ = NULL,
+                                .discount_rate_ = 0.035,
+                                .time_horion_ = NULL) {
   ## Set currency label if none were provided:----
   if(is.null(.units_) | length(.units_) != 1) .units_ = "\u00A3"
+
+  ## Sort out .wtp values:----
+  ### Remove wtp values greater than max WTP set by user:
+  if(is.null(.wtp_))
+    .wtp_ <- c(20000, 30000)
+  if(!is.null(.wtp_))
+    if(length(.wtp_) < 1)
+      .wtp_ <- NULL
+  if(!is.null(.wtp_))
+    .wtp_ <- .wtp_[!is.na(.wtp_)]
+  if(any(.wtp_ > max(.PSA_data$WTPs)))
+    .wtp_ <- c(.wtp_[.wtp_ < max(.PSA_data$WTPs)],
+               max(.PSA_data$WTPs))
+  ### replace unevaluated wtp with nearest replacements:
+  wtp_index_ <- purrr::map_dbl(
+    .x = .wtp_,
+    .f = function(wtp_ = .x) {
+      which.min(
+        abs(
+          wtp_ - .PSA_data$WTPs
+        )
+      )
+    }
+  )
+  .wtp_ <- unique(.PSA_data$WTPs[wtp_index_])
 
   ## Get the ICER table from the result's object:----
   ICER_tbl <- .PSA_data[["ICER"]]

--- a/R/shiny_R6_app.R
+++ b/R/shiny_R6_app.R
@@ -881,10 +881,7 @@ ShinyPSA_R6_App <- R6::R6Class(
       if(self$make_secure) {
         ui <- shinymanager::secure_app(
           ui = ui,
-          theme = bslib::bs_theme(
-            bg = "white",
-            fg = "black"
-          )
+          theme = bslib::bs_theme()
         )
       } else {
         ui
@@ -1256,28 +1253,6 @@ ShinyPSA_R6_App <- R6::R6Class(
           if(!is.null(wtp_))
             if(length(wtp_) < 1)
               wtp_ <- NULL
-          if(!is.null(wtp_))
-            wtp_ <- wtp_[!is.na(wtp_)]
-          if(any(wtp_ > max(rContainer[[sData_name()]]$
-                            get_WTP())))
-            wtp_ <- c(wtp_[wtp_ < max(rContainer[[sData_name()]]$
-                                        get_WTP())],
-                      max(rContainer[[sData_name()]]$
-                            get_WTP()))
-          # replace unevaluated wtp with nearest replacements:
-          wtp_index_ <- purrr::map_dbl(
-            .x = wtp_,
-            .f = function(.wtp_ = .x) {
-              which.min(
-                abs(
-                  .wtp_ - rContainer[[sData_name()]]$
-                    get_WTP()
-                )
-              )
-            }
-          )
-          wtp_ <- unique(rContainer[[sData_name()]]$
-                           get_WTP()[wtp_index_])
           # Pass values to the get_Summary_table function:
           self$iContainer[["sumTbl"]]$
             server(
@@ -1292,16 +1267,16 @@ ShinyPSA_R6_App <- R6::R6Class(
                   .wtp_ = wtp_,
                   .individual_evpi_ =
                     input[[self$iContainer[["popEVPI0"]]$
-                                               get_uiInId()]],
+                             get_uiInId()]],
                   .evpi_population_ =
                     input[[self$iContainer[["popSzEVPI0"]]$
-                                               get_uiInId()]],
+                             get_uiInId()]],
                   .discount_rate_ =
                     input[[self$iContainer[["dsRtEVPI0"]]$
-                                             get_uiInId()]],
+                             get_uiInId()]],
                   .time_horion_ =
                     input[[self$iContainer[["timEVPI0"]]$
-                                           get_uiInId()]]
+                             get_uiInId()]]
                 ),
               .readyDT_ = TRUE
             )
@@ -1820,9 +1795,7 @@ ShinyPSA_R6_App <- R6::R6Class(
               bslib::bs_theme()
             } else {
               bslib::bs_theme(
-                bg = "black",
-                fg = "white",
-                primary = "orange"
+                bootswatch = "solar" #"sandstone"
               )
             }
           )

--- a/R/shiny_R6_elements.R
+++ b/R/shiny_R6_elements.R
@@ -48,7 +48,8 @@ prettySwitch = R6::R6Class(
             inputId = private$uiInput_Id_,
             label = private$label_,
             inline = TRUE,
-            value = .value_
+            value = .value_,
+            status = "success"
           )
         )
       )

--- a/testing.R
+++ b/testing.R
@@ -1412,7 +1412,7 @@ p = plot_eNMB_(PSA_summary2,
 p
 
 t = draw_summary_table_(.PSA_data = PSA_summary,
-                       .wtp_ = c(20000, 30000),
+                       .wtp_ = c(20000, 30000, 1, 555, 1e+10),
                        .beautify_ = TRUE,
                        .long_ = TRUE)
 


### PR DESCRIPTION
Draw_summary_table function can now handle any WTP values, including reevaluated ones. For example, the function would select the closest evaluated value instead of the unevaluated ones.